### PR TITLE
Release/2.2.21 (#14)

### DIFF
--- a/AuthState.cs
+++ b/AuthState.cs
@@ -33,7 +33,10 @@ namespace Intento.MT.Plugin.PropertiesForm
         // in this case no change event call is required
         public static bool internalControlChange = false;
 
-        public StateModeEnum mode;
+		private static string defaultAccountName = "via Intento";
+
+
+		public StateModeEnum mode;
 
         // current credentials StateModeEnum
         public Dictionary<string, string> providerDataAuthDict;
@@ -124,11 +127,11 @@ namespace Intento.MT.Plugin.PropertiesForm
             {
                 formMT.comboBoxCredentialId.Visible = true;
 				if (mode == StateModeEnum.required)
-					formMT.comboBoxCredentialId.Items.Remove("via Intento");
+					formMT.comboBoxCredentialId.Items.Remove(defaultAccountName);
 				else if (formMT.comboBoxCredentialId.SelectedIndex < 0)
 				{
 					formMT.comboBoxCredentialId.SelectedIndexChanged -= providerState.form.comboBoxCredentialId_SelectedIndexChanged;
-					formMT.comboBoxCredentialId.SelectedItem = "via Intento";
+					formMT.comboBoxCredentialId.SelectedItem = defaultAccountName;
 					formMT.comboBoxCredentialId.SelectedIndexChanged += providerState.form.comboBoxCredentialId_SelectedIndexChanged;
 				}
 				if (mode == StateModeEnum.required && formMT.comboBoxCredentialId.SelectedIndex==-1)
@@ -187,6 +190,13 @@ namespace Intento.MT.Plugin.PropertiesForm
 				formMT.comboBoxCredentialId.Visible = true;
 				IList<dynamic> credentials = form.testAuthData != null ? form.testAuthData : form._translate.Accounts(providerState.currentProviderId);
                 сonnectedAccounts = credentials.Select(q => (string)q.credential_id).ToList();
+				string defaultName = credentials.Where(x => (bool)x["default"]).Select(q => (string)q.credential_id).FirstOrDefault();
+				if (defaultName != null)
+				{
+					defaultAccountName = "Default (" + defaultName + ")";
+					formMT.comboBoxCredentialId.Items.Clear();
+					formMT.comboBoxCredentialId.Items.Add(defaultAccountName);
+				}
 				formMT.comboBoxCredentialId.Items.AddRange(сonnectedAccounts.ToArray());
 				if (сonnectedAccounts.Count != 0)
 				{
@@ -202,7 +212,8 @@ namespace Intento.MT.Plugin.PropertiesForm
         public void Clear()
         {
             formMT.comboBoxCredentialId.Items.Clear();
-			formMT.comboBoxCredentialId.Items.Add("via Intento");
+			defaultAccountName = "via Intento";
+			formMT.comboBoxCredentialId.Items.Add(defaultAccountName);
         }
 
         // Something changed in auth settings on form. Need to clear model and glossary settings. 
@@ -374,8 +385,9 @@ namespace Intento.MT.Plugin.PropertiesForm
             {
                 formMT.groupBoxBillingAccount.Enabled = false;
                 formMT.comboBoxCredentialId.Visible = false;
-                formMT.comboBoxCredentialId.Items.Clear();
-				formMT.comboBoxCredentialId.Items.Add("via Intento");
+				defaultAccountName = "via Intento";
+				formMT.comboBoxCredentialId.Items.Clear();
+				formMT.comboBoxCredentialId.Items.Add(defaultAccountName);
             }
         }
 

--- a/ProviderState.cs
+++ b/ProviderState.cs
@@ -412,10 +412,10 @@ namespace Intento.MT.Plugin.PropertiesForm
 					formMT.comboBoxFrom.SelectedItem = fromLanguages[options.FromLanguage];
 				else if (fromLanguages.ContainsKey("en"))
 					formMT.comboBoxFrom.SelectedItem = fromLanguages["en"];
-				else if (!string.IsNullOrWhiteSpace(form.originalOptions.FromLanguage) || fromLanguages.ContainsKey(form.originalOptions.FromLanguage))
+				else if (!string.IsNullOrWhiteSpace(form.originalOptions.FromLanguage) && fromLanguages.ContainsKey(form.originalOptions.FromLanguage))
 					formMT.comboBoxFrom.SelectedItem = fromLanguages[form.originalOptions.FromLanguage];
-				else
-					formMT.comboBoxFrom.SelectedIndex = 1;
+				else if (formMT.comboBoxFrom.Items.Count > 0)
+					formMT.comboBoxFrom.SelectedIndex = 0;
 			}
 
 			if (toLanguages != null)
@@ -430,7 +430,7 @@ namespace Intento.MT.Plugin.PropertiesForm
 					formMT.comboBoxTo.SelectedItem = toLanguages["zh"];
 				else if (!string.IsNullOrWhiteSpace(form.originalOptions.ToLanguage) && toLanguages.ContainsKey(form.originalOptions.ToLanguage) && enPairs.Contains(form.originalOptions.ToLanguage))
 					formMT.comboBoxTo.SelectedItem = toLanguages[form.originalOptions.ToLanguage];
-				else
+				else if (formMT.comboBoxTo.Items.Count > 0)
 					formMT.comboBoxTo.SelectedIndex = 0;
 			}
 		}


### PR DESCRIPTION
* Default account name instead of "via intento" in dropdown
* Fix language combobox index setting
* CONTMS-88 TMS: trados prompsit: Provider selecting errors
* CONTMS-89 TMS: trados prompsit: Selected Prompsit provider is not displayed in Intento plugin settings
* CONTMS-90 TMS: trados prompsit: Some tags translating errors
* CONTMS-91 TMS: trados prompsit: pretranslate doesn't work

Co-authored-by: Vladimir Abramov <mr.vovan@gmail.com>